### PR TITLE
Adding unit-testing with testthat

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,3 +12,6 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.1
 Imports:
     policytree
+Suggests: 
+    testthat (>= 3.0.0)
+Config/testthat/edition: 3

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/tests.html
+# * https://testthat.r-lib.org/reference/test_package.html#special-files
+
+library(testthat)
+library(exhaustivetree)
+
+test_check("exhaustivetree")

--- a/tests/testthat/test-policytree_agreement.R
+++ b/tests/testthat/test-policytree_agreement.R
@@ -1,0 +1,25 @@
+test_that("produces same classifications as policytree", {
+ for (i in 1:10) {
+    n <- 400
+    p <- 4
+    d <- 3
+
+    # Classification task taken from policytree tests
+    X <- round(matrix(rnorm(n * p), n, p),2)
+    Y <- matrix(0, n, d)
+
+    tree_1 <- exhaustive_tree(X,Y,2)
+    tree_2 <- policy_tree(X,Y,2)
+
+    expect_equal(predict(tree_1,X),predict(tree_2,X))
+
+    # Classification task taken from policytree tests
+    X <- matrix(as.numeric(sample(10:20, n * p, replace = TRUE)), n, p)
+    Y <- matrix(0, n, d)
+
+    tree_1 <- exhaustive_tree(X,Y,2)
+    tree_2 <- policy_tree(X,Y,2)
+
+    expect_equal(predict(tree_1,X),predict(tree_2,X))
+ }
+})


### PR DESCRIPTION
Adds tests to make sure that trees I create match those created by the `policytree` package.