### PR TITLE
fix to allow package to compile on windows with Rust > 1.7.0

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -6,7 +6,7 @@ TOOLCHAIN ?= stable-msvc
 TARGET_DIR = ./rust/target
 LIBDIR = $(TARGET_DIR)/$(TARGET)/release
 STATLIB = $(LIBDIR)/libsparsepolicytree.a
-PKG_LIBS = -L$(LIBDIR) -lsparsepolicytree -lws2_32 -ladvapi32 -luserenv -lbcrypt
+PKG_LIBS = -L$(LIBDIR) -lsparsepolicytree -lws2_32 -ladvapi32 -luserenv -lbcrypt -lntdll
 
 all: C_clean
 


### PR DESCRIPTION
issue detailed [here](https://yutani.rbind.io/post/rust-1.70-and-build-failure-on-windows/) 